### PR TITLE
feat: provide a right to stage code to Updater role

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -64,7 +64,7 @@ pub enum Role {
 #[derive(PanicOnDefault, Pausable, Upgradable)]
 #[access_control(role_type(Role))]
 #[upgradable(access_control_roles(
-    code_stagers(Role::DAO),
+    code_stagers(Role::DAO, Role::Updater),
     code_deployers(Role::DAO),
     duration_initializers(Role::DAO),
     duration_update_stagers(Role::DAO),


### PR DESCRIPTION
The PR adds the possibility of staging code for the Updater role. The code deployer is still DAO. Such changes are necessary because it's not convenient to stage code via proposal, where the staging code should be provided with base64-encoded arguments.