### PR TITLE
feat: Downgrader role

### DIFF
--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -59,6 +59,7 @@ pub enum Role {
     Releaser,
     Updater,
     Unpauser,
+    Downgrader,
 }
 
 /// Controller contract for deploying and upgrading contracts.
@@ -465,7 +466,7 @@ impl AuroraControllerFactory {
     }
 
     /// Downgrades the contract with account id.
-    #[access_control_any(roles(Role::DAO))]
+    #[access_control_any(roles(Role::DAO, Role::Downgrader))]
     #[payable]
     pub fn downgrade(&mut self, contract_id: AccountId) -> Promise {
         assert_one_yocto();


### PR DESCRIPTION
This PR adds `Role::Downgrader` role. Grantees of this role are allowed to call `downgrade()` method along with `Role::DAO`